### PR TITLE
Fix namespacing issue in `C++/gtodelta.cpp`

### DIFF
--- a/C++/gtodelta.cpp
+++ b/C++/gtodelta.cpp
@@ -3,6 +3,7 @@
 
 using namespace triqs::gfs;
 using namespace triqs::lattice;
+namespace mesh = triqs::mesh;
 
 int main() {
 


### PR DESCRIPTION
This patch addresses the following compilation failure.
```
[ 83%] Building CXX object CMakeFiles/gtodelta.dir/gtodelta.cpp.o
/home/igor/Physics/TRIQS/3.2/tutorials.git/C++/gtodelta.cpp:20:18: error: use of undeclared identifier 'mesh'; did you mean 'triqs::mesh'?
  auto bz_mesh = mesh::brzone{bz, n_pts};
                 ^~~~
                 triqs::mesh
/home/igor/Physics/TRIQS/3.2/installed/include/triqs/./mesh.hpp:67:18: note: 'triqs::mesh' declared here
namespace triqs::mesh {
                 ^
1 error generated.
```

It should also be cherry-picked to `unstable` and `unstable_executed`.
TRIQS 3.2 clones contents of `unstable_executed` as part of documentation building process, which results in a build failure with `-DBuild_Documentation=ON`.