### PR TITLE
[ctint] Fix scalar valued GF constructor calls

### DIFF
--- a/C++/ctint/c++/ctint.cpp
+++ b/C++/ctint/c++/ctint.cpp
@@ -164,8 +164,8 @@ struct measure_M {
 
 ctint_solver::ctint_solver(double beta_, int n_iw, int n_tau) : beta(beta_) {
 
-  G0_iw       = make_block_gf({"up", "down"}, gf<imfreq, scalar_valued>{{beta, Fermion, n_iw}, {}});
-  G0tilde_tau = make_block_gf({"up", "down"}, gf<imtime, scalar_valued>{{beta, Fermion, n_tau}, {}});
+  G0_iw       = make_block_gf({"up", "down"}, gf<imfreq, scalar_valued>{{beta, Fermion, n_iw}});
+  G0tilde_tau = make_block_gf({"up", "down"}, gf<imtime, scalar_valued>{{beta, Fermion, n_tau}});
   G0tilde_iw  = G0_iw;
   G_iw        = G0_iw;
   M_iw        = G0_iw;


### PR DESCRIPTION
There is a compilation problem in `ctint.cpp` (Clang version 16.0.6). 
```
[  6%] Building CXX object c++/CMakeFiles/ctint_tutorial_c.dir/ctint.cpp.o
/home/igor/Physics/TRIQS/3.2/tutorials.git/C++/ctint/c++/ctint.cpp:167:47: error: call to constructor of 'gf<imfreq, scalar_valued>' is ambiguous
  G0_iw       = make_block_gf({"up", "down"}, gf<imfreq, scalar_valued>{{beta, Fermion, n_iw}, {}});
                                              ^                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/igor/Physics/TRIQS/3.2/installed/include/triqs/./gfs/gf/gf.hpp:247:5: note: candidate constructor
    gf(mesh_t m, data_t dat) : _mesh(std::move(m)), _data(std::move(dat)) {}
    ^
/home/igor/Physics/TRIQS/3.2/installed/include/triqs/./gfs/gf/gf.hpp:254:5: note: candidate constructor
    gf(mesh_t m, target_shape_t shape = {}) : _mesh(std::move(m)), _data(make_data_shape(_mesh, shape)) {}
    ^
/home/igor/Physics/TRIQS/3.2/tutorials.git/C++/ctint/c++/ctint.cpp:168:47: error: call to constructor of 'gf<imtime, scalar_valued>' is ambiguous
  G0tilde_tau = make_block_gf({"up", "down"}, gf<imtime, scalar_valued>{{beta, Fermion, n_tau}, {}});
                                              ^                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/igor/Physics/TRIQS/3.2/installed/include/triqs/./gfs/gf/gf.hpp:247:5: note: candidate constructor
    gf(mesh_t m, data_t dat) : _mesh(std::move(m)), _data(std::move(dat)) {}
    ^
/home/igor/Physics/TRIQS/3.2/installed/include/triqs/./gfs/gf/gf.hpp:254:5: note: candidate constructor
    gf(mesh_t m, target_shape_t shape = {}) : _mesh(std::move(m)), _data(make_data_shape(_mesh, shape)) {}
    ^
2 errors generated.
```