### PR TITLE
better 0/0 handling

### DIFF
--- a/TwoParticleResponse/02-Lindhard.ipynb
+++ b/TwoParticleResponse/02-Lindhard.ipynb
@@ -285,7 +285,7 @@
     "```\n",
     "kmesh = e_k.mesh\n",
     "beta = chi0_wk.mesh[0].beta\n",
-    "chi_Q_ref = np.sum(np.nan_to_num(np.tanh(e_k.data.real * beta/2) / e_k.data.real, nan=0.)) / len(kmesh) \n",
+    "chi_Q_ref = np.sum(np.nan_to_num(np.tanh(e_k.data.real * beta/2) / e_k.data.real, nan=beta/2.0)) / len(kmesh) \n",
     "```\n",
     "\n",
     "Make a combined plot of the Matsubara frequency dependent susceptibility at $\\mathbf{Q}$ and the analytical value of the static response. "

--- a/TwoParticleResponse/solutions/02s-Lindhard.ipynb
+++ b/TwoParticleResponse/solutions/02s-Lindhard.ipynb
@@ -3001,7 +3001,7 @@
     "```\n",
     "kmesh = e_k.mesh\n",
     "beta = chi0_wk.mesh[0].beta\n",
-    "chi_Q_ref = np.sum(np.nan_to_num(np.tanh(e_k.data.real * beta/2) / e_k.data.real, nan=0.)) / len(kmesh) \n",
+    "chi_Q_ref = np.sum(np.nan_to_num(np.tanh(e_k.data.real * beta/2) / e_k.data.real, nan=beta/2.0)) / len(kmesh) \n",
     "```\n",
     "\n",
     "Make a combined plot of the Matsubara frequency dependent susceptibility at $\\mathbf{Q}$ and the analytical value of the static response. "
@@ -4003,7 +4003,7 @@
     "\n",
     "kmesh = e_k.mesh\n",
     "beta = chi0_wk.mesh[0].beta\n",
-    "chi_Q_ref = np.sum(np.nan_to_num(np.tanh(e_k.data.real * beta/2) / e_k.data.real, nan=0.)) / len(kmesh) \n",
+    "chi_Q_ref = np.sum(np.nan_to_num(np.tanh(e_k.data.real * beta/2) / e_k.data.real, nan=beta/2.0)) / len(kmesh) \n",
     "\n",
     "oplot(chi0_wk(all, k_M), mode='R', label=r'$\\mathbf{q}_M$')\n",
     "plt.plot(0, chi_Q_ref, 'ro', label='Analytic')\n",


### PR DESCRIPTION
In the computation of the nesting response there is some handling of a 0-division necessary.
The current implementation just adds 0 to the sum in this case, but since the hyperbolic tangent is linear around 0, we should get beta/2 for this summand